### PR TITLE
Add DokuWiki format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v1.3.2.1
+* Add DokuWiki format option
+
 ## v1.3.2
 * Add keyboard shortcut Ctrl+Shift+U
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ link formats:
 | Format   | Result                                      |
 | -------- | ------------------------------------------- |
 | Markdown | `[page-title-or-selection](url)`            |
+| DokuWiki | `[[url|page-title-or-selection]]`           |
 | HTML     | `<a href="url">page-title-or-selection</a>` |
 | LaTeX    | `\href{url}{page-title-or-selection}`       |
 | XML      | configured separately (see below)           |

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -29,6 +29,9 @@ function getFormattedLink (data) {
     case 'markdown':
       return `[${name}](${data.href})`;
 
+    case 'dokuwiki':
+      return `[[${data.href}|${name}]]`;
+
     case 'html':
       return `<a href="${data.href}">${name}</a>`;
 

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 2,
   "name": "Copy Page Link",
-  "version": "1.3.2",
+  "version": "1.3.2.1",
   "description" : "Inserts the title and URL of the current page into the preferred link format, and copies the result to the clipboard, for pasting into an external document. If text is selected on the page, the selection is used in place of the page title.",
-  "homepage_url": "https://github.com/nhoyt/copy-page-link",
+  "homepage_url": "https://github.com/shrick/copy-page-link",
   "author": "Nicholas Hoyt",
 
 

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -33,6 +33,9 @@ function getFormattedLink (data) {
     case 'markdown':
       return `[${name}](${data.href})`;
 
+    case 'dokuwiki':
+      return `[[${data.href}|${name}]]`;
+
     case 'html':
       return `<a href="${data.href}">${name}</a>`;
 

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 2,
   "name": "Copy Page Link",
-  "version": "1.3.2",
+  "version": "1.3.2.1",
   "description" : "Inserts the title and URL of the current page into the preferred link format, and copies the result to the clipboard, for pasting into an external document. If text is selected on the page, the selection is used in place of the page title.",
-  "homepage_url": "https://github.com/nhoyt/copy-page-link",
+  "homepage_url": "https://github.com/shrick/copy-page-link",
   "author": "Nicholas Hoyt",
 
   "browser_specific_settings": {

--- a/gpp-background.js
+++ b/gpp-background.js
@@ -35,6 +35,9 @@ function getFormattedLink (data) {
     case 'markdown':
       return `[${name}](${data.href})`;
 
+    case 'dokuwiki':
+      return `[[${data.href}|${name}]]`;
+
     case 'html':
       return `<a href="${data.href}">${name}</a>`;
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 2,
   "name": "Copy Page Link",
-  "version": "1.3.2",
+  "version": "1.3.2.1",
   "description" : "Inserts the title and URL of the current page into the preferred link format, and copies the result to the clipboard, for pasting into an external document. If text is selected on the page, the selection is used in place of the page title.",
-  "homepage_url": "https://github.com/nhoyt/copy-page-link",
+  "homepage_url": "https://github.com/shrick/copy-page-link",
   "author": "Nicholas Hoyt",
 
 #ifdef FIREFOX

--- a/shared/options.html
+++ b/shared/options.html
@@ -12,6 +12,7 @@
         <legend>Link Format</legend>
         <div class="grid-formats">
           <label><input type="radio" name="format" value="markdown" id="markdown"> Markdown</label>
+          <label><input type="radio" name="format" value="dokuwiki" id="dokuwiki"> DokuWiki</label>
           <label><input type="radio" name="format" value="html" id="html"> HTML</label>
           <label><input type="radio" name="format" value="latex" id="latex"> LaTeX</label>
           <label><input type="radio" name="format" value="xml" id="xml"> XML</label>


### PR DESCRIPTION
Hi!

Found your nice add-on but missed and added support for DokuWiki links. Maybe you want to integrate it. Tested with Firefox (v75.0) in debugging mode and as unsigned XPI.

**Note 1**: Changed version number by adding an additional 4th part to not conflict with your versioning. Also changed the homepage URL. You probably want to adapt resp. ignore both changes.

**Note 2**: The add-on description, wherever located, then also has to be adjusted to support five link formats now.

Kind regards
shrick